### PR TITLE
Determine item deck GUID dynamically

### DIFF
--- a/item_deck.ttslua
+++ b/item_deck.ttslua
@@ -2,6 +2,36 @@
 #include shared_def
 
 item_deck = {}
+item_deck_GUID_cache = nil
+
+--------------------------------------------------------------------------------
+-- Finds the item deck GUID dynamically.
+--------------------------------------------------------------------------------
+function getItemDeckGUID()
+
+  -- If the cached item deck GUID is still valid, return the cached GUID.
+  if item_deck_GUID_cache ~= nil then
+    local item_deck = getObjectFromGUID(item_deck_GUID_cache)
+    if item_deck ~= nil then
+      log("Existing item deck guid ".. item_deck.guid)
+      return item_deck_GUID_cache
+    end
+  end
+
+  -- Cached item deck GUID is no longer valid, retrieve a new one and cache it.
+  local item_deck_zone_GUID = "b2273d"
+  local table_objects = getAllObjects()
+  for _, table_object in ipairs(table_objects) do
+    for  _, zone in ipairs(table_object.getZones()) do
+      if zone.guid == item_deck_zone_GUID then
+        log("New item deck guid ".. table_object.guid)
+        item_deck_GUID_cache = table_object.guid
+      end
+    end
+  end
+
+  return item_deck_GUID_cache
+end
 
 --------------------------------------------------------------------------------
 -- Draws a card from the item deck if available.
@@ -15,7 +45,7 @@ item_deck = {}
 function item_deck.purchaseFromItemDeck(playerColor, cardNamePrefix,
                                         cardNameForLog)
   local card_name = cardNamePrefix
-  local item_deck_GUID = "de0c10"
+  local item_deck_GUID = getItemDeckGUID()
   local item_deck = getObjectFromGUID(item_deck_GUID)
   if item_deck == nil then
     print("No cards on item deck")


### PR DESCRIPTION
Each time a card deck is re-created, either due to cards being
completely dispensed, or splitted and re-grouped two separate decks, the
new deck is considered a new object and has a new GUID. Therefore we
need to determine the item deck GUID dynamically based on decks placed
in the item deck card zone.