### PR TITLE
Detect dealing item cards to player

### DIFF
--- a/global.ttslua
+++ b/global.ttslua
@@ -1,15 +1,4 @@
-#include shared_def
-
---------------------------------------------------------------------------------
--- Removes tag `tag_in_hand` from the card being played.
---
--- @param playerColor Color of the player trying to draw the card.
--- @param card Card being played by player `playerColor`.
---------------------------------------------------------------------------------
-function onCardPlay(playerColor, card)
-  card.removeTag(shared_def.tag_in_hand)
-  print("Player " .. playerColor .. " played " .. card.getName())
-end
+#include item_card
 
 --------------------------------------------------------------------------------
 -- Determines whether the dropped object is a Card being placed on card play
@@ -17,7 +6,7 @@ end
 --
 -- Should only be called from onObjectDrop.
 --
--- @param object Objecting being dropped.
+-- @param object Object being dropped.
 --------------------------------------------------------------------------------
 function isCardPlayOnDrop(object)
   local card_play_zone_GUID = "dd760d"
@@ -31,8 +20,32 @@ function isCardPlayOnDrop(object)
   return false
 end
 
+--------------------------------------------------------------------------------
+-- Determines whether we have a Card object entering a HandTrigger zone.
+--
+-- Should only be called from onObjectEnterZone.
+--
+-- @param zone Zone the Object `object` is entering.
+-- @param object Object entering Zone `zone`.
+--------------------------------------------------------------------------------
+function isCardEnterHandZone(zone, object)
+  return object.type == "Card" and zone.name == "HandTrigger"
+end
+
+--------------------------------------------------------------------------------
+--
+-- Predefined event handlers.
+--
+--------------------------------------------------------------------------------
+
 function onObjectDrop(playerColor, object)
   if isCardPlayOnDrop(object) then
-    onCardPlay(playerColor, object)
+    item_card.onCardPlay(object, playerColor)
+  end
+end
+
+function onObjectEnterZone(zone, object)
+  if isCardEnterHandZone(zone, object) then
+    item_card.onCardDeal(object)
   end
 end

--- a/item_card.ttslua
+++ b/item_card.ttslua
@@ -1,0 +1,23 @@
+#include shared_def
+
+item_card = {}
+--------------------------------------------------------------------------------
+-- Removes tag `in_hand` from the card being played.
+--
+-- @param card Card being played by player `playerColor`.
+-- @param playerColor Color of the player playing the card.
+--------------------------------------------------------------------------------
+function item_card.onCardPlay(card, playerColor)
+  card.removeTag(shared_def.tag_in_hand)
+  print("Player " .. playerColor .. " played " .. card.getName())
+end
+
+--------------------------------------------------------------------------------
+-- Adds tag `in_hand` to the card being dealt to player.
+--
+-- @param card Card being played by player `playerColor`.
+--------------------------------------------------------------------------------
+function item_card.onCardDeal(card)
+  card.addTag(shared_def.tag_in_hand)
+  print("Card "..card.getName().." is played.")
+end

--- a/item_deck.ttslua
+++ b/item_deck.ttslua
@@ -63,7 +63,6 @@ function item_deck.purchaseFromItemDeck(playerColor, cardNamePrefix,
       if not card.hasTag(shared_def.tag_in_hand) then
         printToColor("You purchased a ".. cardNameForLog .." card!",
                      playerColor, playerColor)
-        card.addTag(shared_def.tag_in_hand)
         card.deal(1, playerColor)
         return
       end


### PR DESCRIPTION
Item cards can be purchased by players or dealt to players when they
move to an item location. The `in_hand` tag is used to distinguish
whether a card is available to be purchased by players. Today only
purchased item cards are tagged with `in_hand`, meaning dealt cards are
still considered available for purchase, which is incorrect.

This change tags item cards with `in_hand` when they are dealt to
players.