### PR TITLE
Use custom button for all item card purchase

### DIFF
--- a/2h_toy_purchase_btn.ttslua
+++ b/2h_toy_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a 2h toy card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function draw2hToyCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "2nd_hand_toy_", "second hand toy")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  draw2hToyCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click,
+                                 "2nd_hand_toy_", "second hand toy")
 end

--- a/dog_leash_purchase_btn.ttslua
+++ b/dog_leash_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a dog leash card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawDogLeashCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "dog_leash_", "dog leash")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawDogLeashCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click, "dog_leash_",
+                                 "dog leash")
 end

--- a/e_collar_purchase_btn.ttslua
+++ b/e_collar_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a Elizabethan collar card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawECollar(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "elizabethan_collar_", "Elizabethan collar")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawECollar(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click, "elizabethan_collar_",
+                                 "Elizabethan collar")
 end

--- a/lib/custom_button.ttslua
+++ b/lib/custom_button.ttslua
@@ -1,17 +1,35 @@
 custom_button = {}
 
-function custom_button.onLoad()
+local DEFAULT_WIDTH = 1000
+local DEFAULT_HEIGHT = 1000
+
+--------------------------------------------------------------------------------
+-- Creates a custom button.
+--------------------------------------------------------------------------------
+function custom_button.onLoad(display_text, width, height)
+  -- Sets up optional parameters.
+  if display_text == nil then
+    display_text = ""
+  end
+  if width == nil then
+    width = DEFAULT_WIDTH
+  end
+  if height == nil then
+    height = DEFAULT_HEIGHT
+  end
+
+  -- Creates the button.
   params = {
       click_function = "click_function",
       function_owner = self,
-      label          = "",
+      label          = display_text,
       position       = {0, 0.2, 0},
       rotation       = {0, 0, 0},
-      width          = 1000,
-      height         = 1000,
+      width          = width,
+      height         = height,
       font_size      = 600,
-      color          = {1, 1, 1},
-      font_color     = {1, 1, 1},
+      color          = {0.8, 0.8, 0.8},
+      font_color     = {0.2, 0.2, 0.2},
       tooltip        = "",
   }
   self.createButton(params)

--- a/lib/purchase_button.ttslua
+++ b/lib/purchase_button.ttslua
@@ -1,0 +1,29 @@
+#include custom_button
+#include item_deck
+
+purchase_button = {}
+
+--------------------------------------------------------------------------------
+-- Creates a custom button.
+--------------------------------------------------------------------------------
+function purchase_button.onLoad()
+  custom_button.onLoad("Buy", 4000, 1000)
+end
+
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+-- @param card_name_prefix Unique identifier of a type of item cards. Item cards
+--        of the same type are grouped by a unique prefix, for example, all dog
+--        leash cards starts with the name "dog_leash_".
+-- @param card_name_log A human readable string used for logging purposes.
+--------------------------------------------------------------------------------
+function purchase_button.click_function(obj, color, alt_click, card_name_prefix,
+                                        card_name_log)
+  custom_button.click_function(obj, color, alt_click)
+  item_deck.drawFromItemDeck(color, card_name_prefix, card_name_log)
+end

--- a/lucky_cookie_purchase_btn.ttslua
+++ b/lucky_cookie_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a lucky cookie card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawLuckyCookieCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "lucky_cookie_", "lucky cookie")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawLuckyCookieCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click, "lucky_cookie_",
+                                 "lucky cookie")
 end

--- a/mango_paradise_purchase_btn.ttslua
+++ b/mango_paradise_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a Mango paradise card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawMangoParasizeCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "mango_paradise_", "mango paradise")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawMangoParasizeCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click,
+                                 "mango_paradise_", "mango paradise")
 end

--- a/poop_bag_purchase_btn.ttslua
+++ b/poop_bag_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a poop bag card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawPoopBagCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "poop_bag_", "poop bag")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawPoopBagCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click,
+                                 "poop_bag_", "poop bag")
 end

--- a/prevention_pills_purchase_btn.ttslua
+++ b/prevention_pills_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a prevention pills card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawPreventionPillsCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "prevention_pills_", "prevention pills")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawPreventionPillsCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click,
+                                 "prevention_pills_", "prevention pills")
 end

--- a/secret_toy_purchase_btn.ttslua
+++ b/secret_toy_purchase_btn.ttslua
@@ -1,14 +1,21 @@
-#include lib/item_deck
+#include lib/purchase_button
 
 --------------------------------------------------------------------------------
--- Draws a secret card from the item deck if available.
---
--- @param playerColor Color of the player trying to draw the card.
+-- Creates a custom button.
 --------------------------------------------------------------------------------
-function drawSecretToyCard(playerColor)
-  item_deck.drawFromItemDeck(playerColor, "secret_toy_", "secret toy")
+function onLoad()
+  purchase_button.onLoad()
 end
 
-function onDrop(playerColor)
-  drawSecretToyCard(playerColor)
+--------------------------------------------------------------------------------
+-- Handler for click, invoked when the custom button is clicked.
+--
+-- @param obj The Object the button is attached to.
+-- @param color Player Color of the player that pressed the button.
+-- @param alt_click True if a button other than left-click was used to click the
+--        button.
+--------------------------------------------------------------------------------
+function click_function(obj, color, alt_click)
+  purchase_button.click_function(obj, color, alt_click,
+                                 "secret_toy_", "secret toy")
 end


### PR DESCRIPTION
Using custom buttons allows us to display helpful text on the button,
and to lock the button to prevent players from moving the buttons
around.