### PR TITLE
Use description for tooltip in custom objects

### DIFF
--- a/lib/custom_button.ttslua
+++ b/lib/custom_button.ttslua
@@ -30,7 +30,7 @@ function custom_button.onLoad(display_text, width, height)
       font_size      = 600,
       color          = {0.8, 0.8, 0.8},
       font_color     = {0.2, 0.2, 0.2},
-      tooltip        = "",
+      tooltip        = self.getDescription(),
   }
   self.createButton(params)
 end

--- a/lib/custom_checkbox.ttslua
+++ b/lib/custom_checkbox.ttslua
@@ -7,9 +7,8 @@ local CHECKBOX_BTN_IDX = 1
 -- displaying the content of the checkbox.
 --
 -- @param display_text Default text to be displayed on load.
--- @param tool_tip Text to display when mouse hovers over the buttons.
 --------------------------------------------------------------------------------
-function custom_checkbox.onLoad(display_text, tool_tip)
+function custom_checkbox.onLoad(display_text)
   params = {
       click_function = "click_function",
       function_owner = self,
@@ -21,7 +20,7 @@ function custom_checkbox.onLoad(display_text, tool_tip)
       font_size      = 600,
       color          = {0.9, 0.9, 0.9},
       font_color     = {0.3, 0.3, 0.3},
-      tooltip        = tool_tip,
+      tooltip        = self.getDescription(),
   }
   self.createButton(params)
 
@@ -36,7 +35,7 @@ function custom_checkbox.onLoad(display_text, tool_tip)
       font_size      = 600,
       color          = {0.9, 0.9, 0.9},
       font_color     = {0.3, 0.3, 0.3},
-      tooltip        = tool_tip,
+      tooltip        = self.getDescription(),
   }
   self.createButton(params)
 end

--- a/lib/custom_counter.ttslua
+++ b/lib/custom_counter.ttslua
@@ -84,7 +84,7 @@ function custom_counter.onLoad(default_val)
       font_size      = 600,
       color          = {0.2, 0.2, 0.2},
       font_color     = {1, 1, 1},
-      tooltip        = "",
+      tooltip        = self.getDescription(),
   }
   self.createButton(params)
 end

--- a/lib/persistent_attributes.ttslua
+++ b/lib/persistent_attributes.ttslua
@@ -2,18 +2,11 @@
 
 persistent_attributes = {}
 
-local display_text_to_rules = {}
-display_text_to_rules["Spayed"] = "Must pay 2H and stay 1 day in the vet to get spayed; pre-requisit for pet insurance"
-display_text_to_rules["Neutered"] = "Must pay 2H and stay 1 day in the vet to get neutered; pre-requisit for pet insurance"
-display_text_to_rules["Pet Insurance"] = "Must be spayed first; cost 2H; VP=1; H loss -1 in the vet; can be bought in pet stores"
-display_text_to_rules["CGC Certificate"] = "Training must be >=3; cost 2H; VP=1; can use transportation; can be bought in pet stores"
-display_text_to_rules["Dog Luxury Bed"] = "Cleanliness must be >=3; cost 2H; VP=1; no relationship loss in the hotel; can be bought in pet stores"
-
 --------------------------------------------------------------------------------
 -- Creates a custom checkbox to represent a persistent attribute.
 --------------------------------------------------------------------------------
 function persistent_attributes.onLoad(display_text)
-  custom_checkbox.onLoad(display_text, display_text_to_rules[display_text])
+  custom_checkbox.onLoad(display_text)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
For custom checkbox, button, and counter, display object description as
button tooltips. Note once the description change, a reload is required.