### PR TITLE
Auto return item and fate cards to deck

### DIFF
--- a/board.ttslua
+++ b/board.ttslua
@@ -1,0 +1,64 @@
+#include lib/item_deck
+#include lib/fate_deck
+
+--------------------------------------------------------------------------------
+-- Returns true if `obj` has tag "item_cards".
+--
+-- @param obj An object in the game.
+--------------------------------------------------------------------------------
+local function isItemCards(obj)
+  return obj.hasTag("item_cards")
+end
+
+--------------------------------------------------------------------------------
+-- Returns true if `obj` has tag "fate_cards".
+--
+-- @param obj An object in the game.
+--------------------------------------------------------------------------------
+local function isFateCards(obj)
+  return obj.hasTag("fate_cards")
+end
+
+--------------------------------------------------------------------------------
+-- Puts an item or fate card back to its original deck or deck position.
+--
+-- @param obj An object in the game.
+--------------------------------------------------------------------------------
+local function returnItemOrFateCardsToDeck(obj)
+  local deck = nil
+  local deckPosition = nil
+
+  if isItemCards(obj) then
+    deck = getObjectFromGUID(item_deck.getItemDeckGUID())
+    deckPosition = item_deck.getItemDeckPosition()
+  end
+
+  if isFateCards(obj) then
+    deck = getObjectFromGUID(fate_deck.getFateDeckGUID())
+    deckPosition = fate_deck.getFateDeckPosition()
+
+  end
+
+  -- `deck` could be nil if all cards from that deck were taken out, in that
+  -- case, put the card back to the deck position.
+  if deck ~= nil then
+    deck.putObject(obj)
+    return
+  end
+
+  if deckPosition ~= nil then
+    if not obj.is_face_down then
+      obj.flip()
+    end
+    position_param = {
+        x = deckPosition[1],
+        y = deckPosition[2],
+        z = deckPosition[3],
+    }
+    obj.setPositionSmooth(position_param, false, false)
+  end
+end
+
+function onCollisionEnter(info)
+  returnItemOrFateCardsToDeck(info.collision_object)
+end

--- a/global.ttslua
+++ b/global.ttslua
@@ -152,3 +152,9 @@ function onObjectLeaveZone(zone, object)
     updatePlayerVp(zone.getValue(), -1)
   end
 end
+
+function onObjectLeaveContainer(container, leave_object)
+  if container.type == "Deck" then
+    leave_object.setTags(container.getTags())
+  end
+end

--- a/lib/fate_deck.ttslua
+++ b/lib/fate_deck.ttslua
@@ -1,12 +1,13 @@
 #include deck
 
 fate_deck = {}
-fate_deck_GUID_cache = nil
+local fate_deck_GUID_cache = nil
+local FATE_DECK_ZONE_GUID = "4d2408"
 
 --------------------------------------------------------------------------------
 -- Finds the fate deck GUID dynamically.
 --------------------------------------------------------------------------------
-function getFateDeckGUID()
+function fate_deck.getFateDeckGUID()
   -- If the cached fate deck GUID is still valid, return the cached GUID.
   if fate_deck_GUID_cache ~= nil then
     local fate_deck = getObjectFromGUID(fate_deck_GUID_cache)
@@ -17,8 +18,17 @@ function getFateDeckGUID()
   end
 
   -- Cached fate deck GUID is no longer valid, retrieve a new one and cache it.
-  fate_deck_GUID_cache = deck.getDeckFromZoneGUID("4d2408")
+  fate_deck_GUID_cache = deck.getDeckFromZoneGUID(FATE_DECK_ZONE_GUID)
   return fate_deck_GUID_cache
+end
+
+--------------------------------------------------------------------------------
+-- Returns the fate deck position, which is defined to be the fate deck zone
+-- potision.
+--------------------------------------------------------------------------------
+function fate_deck.getFateDeckPosition()
+  deck_zone = getObjectFromGUID(FATE_DECK_ZONE_GUID)
+  return deck_zone.getPosition()
 end
 
 --------------------------------------------------------------------------------
@@ -31,5 +41,5 @@ end
 -- @param card_name A human readable string used for logging purposes.
 --------------------------------------------------------------------------------
 function fate_deck.drawFromFateDeck(player_color, card_prefix, card_name)
-  deck.drawFromDeck(player_color, getFateDeckGUID(), "", "random fate")
+  deck.drawFromDeck(player_color, fate_deck.getFateDeckGUID(), "", "random fate")
 end

--- a/lib/fate_deck.ttslua
+++ b/lib/fate_deck.ttslua
@@ -24,7 +24,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Returns the fate deck position, which is defined to be the fate deck zone
--- potision.
+-- position.
 --------------------------------------------------------------------------------
 function fate_deck.getFateDeckPosition()
   deck_zone = getObjectFromGUID(FATE_DECK_ZONE_GUID)

--- a/lib/item_deck.ttslua
+++ b/lib/item_deck.ttslua
@@ -1,12 +1,13 @@
 #include deck
 
 item_deck = {}
-item_deck_GUID_cache = nil
+local item_deck_GUID_cache = nil
+local ITEM_DECK_ZONE_GUID = "c0a960"
 
 --------------------------------------------------------------------------------
 -- Finds the item deck GUID dynamically.
 --------------------------------------------------------------------------------
-function getItemDeckGUID()
+function item_deck.getItemDeckGUID()
   -- If the cached item deck GUID is still valid, return the cached GUID.
   if item_deck_GUID_cache ~= nil then
     local item_deck = getObjectFromGUID(item_deck_GUID_cache)
@@ -17,8 +18,17 @@ function getItemDeckGUID()
   end
 
   -- Cached item deck GUID is no longer valid, retrieve a new one and cache it.
-  item_deck_GUID_cache = deck.getDeckFromZoneGUID("c0a960")
+  item_deck_GUID_cache = deck.getDeckFromZoneGUID(ITEM_DECK_ZONE_GUID)
   return item_deck_GUID_cache
+end
+
+--------------------------------------------------------------------------------
+-- Returns the item deck position, which is defined to be the item deck zone
+-- potision.
+--------------------------------------------------------------------------------
+function item_deck.getItemDeckPosition()
+  deck_zone = getObjectFromGUID(ITEM_DECK_ZONE_GUID)
+  return deck_zone.getPosition()
 end
 
 --------------------------------------------------------------------------------
@@ -31,5 +41,5 @@ end
 -- @param card_name A human readable string used for logging purposes.
 --------------------------------------------------------------------------------
 function item_deck.drawFromItemDeck(player_color, card_prefix, card_name)
-  deck.drawFromDeck(player_color, getItemDeckGUID(), card_prefix, card_name)
+  deck.drawFromDeck(player_color, item_deck.getItemDeckGUID(), card_prefix, card_name)
 end

--- a/lib/item_deck.ttslua
+++ b/lib/item_deck.ttslua
@@ -24,7 +24,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Returns the item deck position, which is defined to be the item deck zone
--- potision.
+-- position.
 --------------------------------------------------------------------------------
 function item_deck.getItemDeckPosition()
   deck_zone = getObjectFromGUID(ITEM_DECK_ZONE_GUID)


### PR DESCRIPTION
When an item or fate card is played, we relied on game master to
manually put those cards back into the decks, this is a lot of
unnecessary mechanical work on game master.

With this change, when any item or fate cards is placed on the game
board, it is automatically returned to its deck.