### PR TITLE
Hide item cards when enter hand zone

### DIFF
--- a/board.ttslua
+++ b/board.ttslua
@@ -2,24 +2,6 @@
 #include lib/fate_deck
 
 --------------------------------------------------------------------------------
--- Returns true if `obj` has tag "item_cards".
---
--- @param obj An object in the game.
---------------------------------------------------------------------------------
-local function isItemCards(obj)
-  return obj.hasTag("item_cards")
-end
-
---------------------------------------------------------------------------------
--- Returns true if `obj` has tag "fate_cards".
---
--- @param obj An object in the game.
---------------------------------------------------------------------------------
-local function isFateCards(obj)
-  return obj.hasTag("fate_cards")
-end
-
---------------------------------------------------------------------------------
 -- Puts an item or fate card back to its original deck or deck position.
 --
 -- @param obj An object in the game.
@@ -28,35 +10,47 @@ local function returnItemOrFateCardsToDeck(obj)
   local deck = nil
   local deckPosition = nil
 
-  if isItemCards(obj) then
+  if not item_deck.isItemCard(obj) and not fate_deck.isFateCard(obj) then
+    return
+  end
+  log_utils.info("Returning card "..obj.getGUID().." to its deck.")
+
+  if item_deck.isItemCard(obj) then
+    -- Item cards are hidden from other players when drawn, so unhid from
+    -- all players when played.
+    obj.setHiddenFrom()
     deck = getObjectFromGUID(item_deck.getItemDeckGUID())
     deckPosition = item_deck.getItemDeckPosition()
   end
 
-  if isFateCards(obj) then
+  if fate_deck.isFateCard(obj) then
     deck = getObjectFromGUID(fate_deck.getFateDeckGUID())
     deckPosition = fate_deck.getFateDeckPosition()
-
   end
 
   -- `deck` could be nil if all cards from that deck were taken out, in that
   -- case, put the card back to the deck position.
-  if deck ~= nil then
-    deck.putObject(obj)
-    return
-  end
+  Wait.time(
+    function()
+      if deck ~= nil then
+        deck.putObject(obj)
+        return
+      end
 
-  if deckPosition ~= nil then
-    if not obj.is_face_down then
-      obj.flip()
-    end
-    position_param = {
-        x = deckPosition[1],
-        y = deckPosition[2],
-        z = deckPosition[3],
-    }
-    obj.setPositionSmooth(position_param, false, false)
-  end
+      if deckPosition ~= nil then
+        if not obj.is_face_down then
+          obj.flip()
+        end
+        position_param = {
+            x = deckPosition[1],
+            y = deckPosition[2],
+            z = deckPosition[3],
+        }
+        obj.setPositionSmooth(position_param, false, false)
+      end
+    end,
+    3
+  )
 end
 
 function onCollisionEnter(info)

--- a/global.ttslua
+++ b/global.ttslua
@@ -1,6 +1,5 @@
-#include lib/utils
-#include lib/log_utils
-#include lib/shared_def
+
+#include lib/item_deck
 
 --------------------------------------------------------------------------------
 -- Determines whether we have an item card with victory point entering or leaving
@@ -114,6 +113,34 @@ function getVpFromAchievementCard(achievement_card)
 end
 
 --------------------------------------------------------------------------------
+-- Returns true if `object` is an item card and `zone` is a hand zone.
+--
+-- @param zone A zone.
+-- @param object An object.
+--------------------------------------------------------------------------------
+local function isItemCardEnterHandZone(zone, object)
+  return zone.type == "Hand" and item_deck.isItemCard(object)
+end
+
+--------------------------------------------------------------------------------
+-- Hides `card` from all players other than the zone owner and the game master.
+--
+-- @param zone A zone.
+-- @param card A card to be hidden from.
+--------------------------------------------------------------------------------
+local function hideCardFromOtherPlayers(zone, card)
+  local player_color = zone.getValue()
+  local all_player_colors = Player.getAvailableColors()
+  local hide_from_players = {}
+  for i, color in ipairs(all_player_colors) do
+    if color ~= player_color and color ~= "Black" then
+      table.insert(hide_from_players, color)
+    end
+  end
+  card.setHiddenFrom(hide_from_players)
+end
+
+--------------------------------------------------------------------------------
 --
 -- Predefined event handlers.
 --
@@ -129,6 +156,10 @@ function onObjectEnterZone(zone, object)
     updatePlayerVp(getAchievementZonePlayerColor(zone),
                    getVpFromAchievementCard(object))
     return
+  end
+
+  if isItemCardEnterHandZone(zone, object) then
+    hideCardFromOtherPlayers(zone, object)
   end
 
   if isVpItemCardEnterOrLeaveHandZone(zone, object) then

--- a/lib/fate_deck.ttslua
+++ b/lib/fate_deck.ttslua
@@ -43,3 +43,12 @@ end
 function fate_deck.drawFromFateDeck(player_color, card_prefix, card_name)
   deck.drawFromDeck(player_color, fate_deck.getFateDeckGUID(), "", "random fate")
 end
+
+--------------------------------------------------------------------------------
+-- Returns true if `obj` has tag "fate_cards".
+--
+-- @param obj An object in the game.
+--------------------------------------------------------------------------------
+function fate_deck.isFateCard(obj)
+  return obj.hasTag("fate_cards")
+end

--- a/lib/item_deck.ttslua
+++ b/lib/item_deck.ttslua
@@ -43,3 +43,12 @@ end
 function item_deck.drawFromItemDeck(player_color, card_prefix, card_name)
   deck.drawFromDeck(player_color, item_deck.getItemDeckGUID(), card_prefix, card_name)
 end
+
+--------------------------------------------------------------------------------
+-- Returns true if `obj` has tag "item_cards".
+--
+-- @param obj An object in the game.
+--------------------------------------------------------------------------------
+function item_deck.isItemCard(obj)
+  return obj.hasTag("item_cards")
+end


### PR DESCRIPTION
Game rules allow item cards to be stolen from one player to another,
however as soon as item card leaves hand zone it is revealed to every
player, which is undesirable.

With this change, as soon as an item card is drawn to a player's hand,
it is hidden from everyone and except the holding player and game
master. The card remains hidden until played on board.

A 3 second delay is added before a played card is returned to its deck,
to allow playered to read the content of the card with ample time.