### PR TITLE
Reveals item cards when it's played on the board

### DIFF
--- a/board.ttslua
+++ b/board.ttslua
@@ -56,7 +56,7 @@ local function returnItemOrFateCardsToDeck(obj)
         obj.setPositionSmooth(position_param, false, false)
       end
     end,
-    3
+    1
   )
 end
 

--- a/global.ttslua
+++ b/global.ttslua
@@ -1,4 +1,3 @@
-
 #include lib/item_deck
 
 --------------------------------------------------------------------------------
@@ -141,6 +140,17 @@ local function hideCardFromOtherPlayers(zone, card)
 end
 
 --------------------------------------------------------------------------------
+-- Returns true if `object` is an item card and `zone` is a the card play
+-- scripting zone identified by the GUID.
+--
+-- @param zone A zone.
+-- @param object An object.
+--------------------------------------------------------------------------------
+local function isItemCardEnterCardPlayZone(zone, object)
+  return zone.getGUID() == "411eed" and item_deck.isItemCard(object)
+end
+
+--------------------------------------------------------------------------------
 --
 -- Predefined event handlers.
 --
@@ -160,10 +170,17 @@ function onObjectEnterZone(zone, object)
 
   if isItemCardEnterHandZone(zone, object) then
     hideCardFromOtherPlayers(zone, object)
+    return
   end
 
   if isVpItemCardEnterOrLeaveHandZone(zone, object) then
     updatePlayerVp(zone.getValue(), 1)
+    return
+  end
+
+  if isItemCardEnterCardPlayZone(zone, object) then
+    log_utils.info("Item card "..object.getName().." is revealed on the table")
+    object.setHiddenFrom()
   end
 end
 


### PR DESCRIPTION
If players want to see the item card and don't want it returned to the
deck yet, they can place the item card anywhere on the table besides the
main board.

With this change we can also reduce the time delay for returning cards
to deck, since players can keep the card on table for viewing.